### PR TITLE
remove unnecessary "model."

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -84,7 +84,7 @@ update msg model =
         MoveRight usState ->
             ( { model
                 | leftListbox =
-                    deleteItemFromList usState model.leftListbox
+                    deleteItemFromList usState leftListbox
                 , rightListbox = rightListbox ++ [ usState ]
               }
             , Cmd.none


### PR DESCRIPTION
`update`の中の`leftListbox`にはすでに`model.leftListbox`が束縛されているため、"model."は不必要なので消しました